### PR TITLE
Implemented the test suite for all Match-Related domains and factories || Fixed the merging conflict || Added methods to the Helper Class

### DIFF
--- a/src/main/java/za/ac/cput/entity/Location.java
+++ b/src/main/java/za/ac/cput/entity/Location.java
@@ -10,6 +10,7 @@ public class Location {
     private String stadiumName;
 
     private Location(Builder builder) {
+        this.locationId = builder.locationId;
         this.stadiumName = builder.stadiumName;
     }
 

--- a/src/main/java/za/ac/cput/entity/Match.java
+++ b/src/main/java/za/ac/cput/entity/Match.java
@@ -13,6 +13,7 @@ public class Match {
     private String time;
 
     private Match(Builder builder) {
+        this.matchId = builder.matchId;
         this.kitType = builder.kitType;
         this.opponent = builder.opponent;
         this.date = builder.date;

--- a/src/main/java/za/ac/cput/factory/KitFactory.java
+++ b/src/main/java/za/ac/cput/factory/KitFactory.java
@@ -1,6 +1,7 @@
 package za.ac.cput.factory;
 
 import za.ac.cput.entity.Kit;
+import za.ac.cput.util.Helper;
 
 /*
  * @author Karl Haupt (220236585)
@@ -10,6 +11,8 @@ import za.ac.cput.entity.Kit;
 public class KitFactory {
 
     public static Kit createKit(String kitType, String kitColour, String kitBrand) {
+        if(isValidParameters(kitType, kitColour)) throw new IllegalStateException("Invalid values");
+
         var kit = new Kit.Builder()
                 .setKitType(kitType)
                 .setKitColor(kitColour)
@@ -17,5 +20,9 @@ public class KitFactory {
                 .build();
 
         return kit;
+    }
+
+    private static boolean isValidParameters(String kitType, String kitColour) {
+        return (Helper.isNull(kitType) || Helper.isNull(kitColour) || Helper.isEmpty(kitType) || Helper.isEmpty(kitColour));
     }
 }

--- a/src/main/java/za/ac/cput/factory/LocationFactory.java
+++ b/src/main/java/za/ac/cput/factory/LocationFactory.java
@@ -11,6 +11,8 @@ import za.ac.cput.util.Helper;
 public class LocationFactory {
 
     public static Location createLocation(String stadiumName) {
+        if(Helper.isNull(stadiumName) || Helper.isEmpty(stadiumName)) throw new IllegalStateException("Invalid value");
+
         String locationID = Helper.generateID();
         var location = new Location.Builder()
                 .setLocationId(locationID)

--- a/src/main/java/za/ac/cput/factory/MatchFactory.java
+++ b/src/main/java/za/ac/cput/factory/MatchFactory.java
@@ -11,6 +11,8 @@ import za.ac.cput.util.Helper;
 public class MatchFactory {
 
     public static Match createMatch(String opponent, String kitType, String date, String time) {
+        if(isInvalidParameters(opponent, kitType, date, time)) throw new IllegalStateException("Invalid values");
+
         String matchID = Helper.generateID();
         var match = new Match.Builder()
                 .setMatchId(matchID)
@@ -21,5 +23,10 @@ public class MatchFactory {
                 .build();
 
         return match;
+    }
+
+    private static boolean isInvalidParameters(String opponent, String kitType, String date, String time) {
+        return (Helper.isNull(opponent) || Helper.isNull(kitType) || Helper.isNull(date) || Helper.isNull(time) ||
+                Helper.isEmpty(opponent) || Helper.isEmpty(kitType) || Helper.isEmpty(date) || Helper.isEmpty(time));
     }
 }

--- a/src/main/java/za/ac/cput/factory/MatchLocationFactory.java
+++ b/src/main/java/za/ac/cput/factory/MatchLocationFactory.java
@@ -1,6 +1,7 @@
 package za.ac.cput.factory;
 
 import za.ac.cput.entity.MatchLocation;
+import za.ac.cput.util.Helper;
 
 /*
  * @author Karl Haupt (220236585)
@@ -10,11 +11,22 @@ import za.ac.cput.entity.MatchLocation;
 public class MatchLocationFactory {
 
     public static MatchLocation createMatchLocation(String locationID, String matchID) {
+        if(isParametersNull(locationID, matchID) || isParametersEmpty(locationID, matchID))
+            throw new IllegalStateException("Invalid values");
+
         var matchLocation = new MatchLocation.Builder()
                 .setLocationId(locationID)
                 .setMatchId(matchID)
                 .build();
 
         return matchLocation;
+    }
+
+    private static boolean isParametersNull(String locationID, String matchID) {
+        return Helper.isNull(locationID) || Helper.isNull(matchID);
+    }
+
+    private static boolean isParametersEmpty(String locationID, String matchID) {
+        return Helper.isEmpty(locationID) || Helper.isEmpty(matchID);
     }
 }

--- a/src/main/java/za/ac/cput/factory/MatchScoreFactory.java
+++ b/src/main/java/za/ac/cput/factory/MatchScoreFactory.java
@@ -1,6 +1,7 @@
 package za.ac.cput.factory;
 
 import za.ac.cput.entity.MatchScore;
+import za.ac.cput.util.Helper;
 
 /*
  * @author Karl Haupt (220236585)
@@ -9,6 +10,9 @@ import za.ac.cput.entity.MatchScore;
 public class MatchScoreFactory {
 
     public static MatchScore createMatchScore(String matchID, byte opponentScore, byte teamScore) {
+        if(Helper.isNull(matchID) || Helper.isEmpty(matchID) ||
+           !isPositive(opponentScore) || !isPositive(teamScore)) throw  new IllegalStateException("Invalid values");
+
         var matchScore = new MatchScore.Builder()
                 .setMatchID(matchID)
                 .setOpponentScore(opponentScore)
@@ -16,5 +20,9 @@ public class MatchScoreFactory {
                 .build();
 
         return matchScore;
+    }
+
+    private static boolean isPositive(byte number) {
+        return (number >= 0);
     }
 }

--- a/src/main/java/za/ac/cput/util/Helper.java
+++ b/src/main/java/za/ac/cput/util/Helper.java
@@ -6,4 +6,12 @@ public class Helper {
     public static String generateID() {
         return UUID.randomUUID().toString();
     }
+
+    public static boolean isNull(String value) {
+        return value == null;
+    }
+
+    public static boolean isEmpty(String value) {
+        return value.equals("");
+    }
 }

--- a/src/test/java/za/ac/cput/entity/KitTest.java
+++ b/src/test/java/za/ac/cput/entity/KitTest.java
@@ -1,0 +1,40 @@
+package za.ac.cput.entity;
+
+/*
+ * @author Karl Haupt (220236585)
+ * KitTest.java -> is a testing class for the Test domain.
+ */
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class KitTest {
+    private Kit kit;
+
+    @BeforeEach
+    void setUp() {
+        kit = new Kit.Builder().setKitType("Home Kit").setKitColor("Black").setKitBrand("Adidas").build();
+    }
+
+    @Test
+    public void testKitForNull() {
+        assertNotNull(kit);
+    }
+
+    @Test
+    public void testKitTypeValue() {
+        assertEquals("Home Kit", kit.getKitType());
+    }
+
+    @Test
+    public void testKitColorValue() {
+        assertEquals("Black", kit.getKitColor());
+    }
+
+    @Test
+    public void testKitBrandValue() {
+        assertEquals("Adidas", kit.getKitBrand());
+    }
+}

--- a/src/test/java/za/ac/cput/entity/LocationTest.java
+++ b/src/test/java/za/ac/cput/entity/LocationTest.java
@@ -1,0 +1,36 @@
+package za.ac.cput.entity;
+
+/*
+ * @author Karl Haupt (220236585)
+ * LocationTest.java -> is a testing class for the Location domain.
+ */
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class LocationTest {
+    private Location location;
+
+    @BeforeEach
+    void setUp() {
+        location = new Location.Builder().setLocationId("1").setStadiumName("Cape Town Stadium").build();
+    }
+
+    @Test
+    public void testLocationForNull() {
+        assertNotNull(location);
+    }
+
+    @Test
+    public void testLocationIDValue() {
+        assertEquals("1", location.getLocationId());
+    }
+
+    @Test
+    public void testStadiumNameValue() {
+        assertEquals("Cape Town Stadium", location.getStadiumName());
+    }
+
+}

--- a/src/test/java/za/ac/cput/entity/MatchLocationTest.java
+++ b/src/test/java/za/ac/cput/entity/MatchLocationTest.java
@@ -1,0 +1,35 @@
+package za.ac.cput.entity;
+
+/*
+ * @author Karl Haupt (220236585)
+ * MatchLocationTest.java -> is a testing class for the MatchLocation domain.
+ */
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class MatchLocationTest {
+    private MatchLocation matchLocation;
+
+    @BeforeEach
+    void setUp() {
+        matchLocation = new MatchLocation.Builder().setMatchId("1").setLocationId("1").build();
+    }
+
+    @Test
+    public void testMatchLocationForNull() {
+        assertNotNull(matchLocation);
+    }
+
+    @Test
+    public void testMatchIDValue() {
+        assertEquals("1", matchLocation.getMatchId());
+    }
+
+    @Test
+    public void testLocationIDValue() {
+        assertEquals("1", matchLocation.getLocationId());
+    }
+}

--- a/src/test/java/za/ac/cput/entity/MatchScoreTest.java
+++ b/src/test/java/za/ac/cput/entity/MatchScoreTest.java
@@ -1,0 +1,48 @@
+package za.ac.cput.entity;
+
+/*
+ * @author Karl Haupt (220236585)
+ * MatchScoreTest.java -> is a testing class for the MatchScore domain.
+ */
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class MatchScoreTest {
+    private MatchScore matchScore;
+    byte opponentScore;
+    byte teamScore;
+
+    @BeforeEach
+    void setUp() {
+        opponentScore = 2;
+        teamScore = 3;
+        matchScore = new MatchScore.Builder()
+                .setMatchID("1")
+                .setOpponentScore(opponentScore)
+                .setTeamScore(teamScore)
+                .build();
+    }
+
+    @Test
+    public void testMatchScoreForNull() {
+        assertNotNull(matchScore);
+    }
+
+    @Test
+    public void testMatchIDValue() {
+        assertEquals("1", matchScore.getMatchID());
+    }
+
+    @Test
+    public void testOpponentScoreValue() {
+        assertEquals(opponentScore, matchScore.getOpponentScore());
+    }
+
+    @Test
+    public void testTeamScoreValue() {
+        assertEquals(teamScore, matchScore.getTeamScore());
+    }
+}

--- a/src/test/java/za/ac/cput/entity/MatchTest.java
+++ b/src/test/java/za/ac/cput/entity/MatchTest.java
@@ -1,0 +1,54 @@
+package za.ac.cput.entity;
+
+/*
+ * @author Karl Haupt (220236585)
+ * MatchTest.java -> is a testing class for the Match domain.
+ */
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class MatchTest {
+    private Match match;
+
+    @BeforeEach
+    void setUp() {
+        match = new Match.Builder().setMatchId("1")
+                .setKitType("Away Kit")
+                .setOpponent("Team B")
+                .setDate("14 May 2022")
+                .setTime("14:00").build();
+    }
+
+    @Test
+    public void testMatchForNull() {
+        assertNotNull(match);
+    }
+
+    @Test
+    public void testMatchIDValue() {
+        assertEquals("1", match.getMatchId());
+    }
+
+    @Test
+    public void testKitTypeValue() {
+        assertEquals("Away Kit", match.getKitType());
+    }
+
+    @Test
+    public void testOpponentValue() {
+        assertEquals("Team B", match.getOpponent());
+    }
+
+    @Test
+    public void testDateValue() {
+        assertEquals("14 May 2022", match.getDate());
+    }
+
+    @Test
+    public void testTimeValue() {
+        assertEquals("14:00", match.getTime());
+    }
+}

--- a/src/test/java/za/ac/cput/factory/KitFactoryTest.java
+++ b/src/test/java/za/ac/cput/factory/KitFactoryTest.java
@@ -1,0 +1,64 @@
+package za.ac.cput.factory;
+
+/*
+ * @author Karl Haupt (220236585)
+ * KitFactoryTest.java -> is a testing class that is used to test the KitFactory.
+ */
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import za.ac.cput.entity.Kit;
+import static org.junit.jupiter.api.Assertions.*;
+
+class KitFactoryTest {
+    private Kit kit;
+
+    @BeforeEach
+    void setUp() {
+        kit = KitFactory.createKit("Away Kit", "Yellow", "Adidas");
+    }
+
+    @Test
+    public void testKitFactoryCreate() {
+        assertNotNull(kit);
+    }
+
+    @Test
+    public void testValueKitType() {
+        assertEquals("Away Kit", kit.getKitType());
+    }
+
+    @Test
+    public void testValueKitColour() {
+        assertEquals("Yellow", kit.getKitColor());
+    }
+
+    @Test
+    public void testValueKitBrand() {
+        assertEquals("Adidas", kit.getKitBrand());
+    }
+
+    @Test
+    public void testKitFactoryForNull() {
+        Exception exception = assertThrows(IllegalStateException.class, () -> {
+            KitFactory.createKit(null, null, null);
+        });
+
+        String expectedMessage = "Invalid values";
+        String actualMessage = exception.getMessage();
+
+        assertTrue(actualMessage.contains(expectedMessage));
+    }
+
+    @Test
+    public void testKitFactoryForEmptyString() {
+        Exception exception = assertThrows(IllegalStateException.class, () -> {
+            KitFactory.createKit("", "", "");
+        });
+
+        String expectedMessage = "Invalid values";
+        String actualMessage = exception.getMessage();
+
+        assertTrue(actualMessage.contains(expectedMessage));
+    }
+}

--- a/src/test/java/za/ac/cput/factory/LocationFactoryTest.java
+++ b/src/test/java/za/ac/cput/factory/LocationFactoryTest.java
@@ -1,31 +1,30 @@
 package za.ac.cput.factory;
 
-import org.junit.jupiter.api.AfterEach;
+/*
+ * @author Karl Haupt (220236585)
+ * LocationFactoryTest.java -> is a testing class that is used to test the LocationFactory class.
+ */
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-
+import za.ac.cput.entity.Location;
 import static org.junit.jupiter.api.Assertions.*;
 
 class LocationFactoryTest {
+    private Location location;
 
-
-//    @BeforeEach
-//    void setUp() {
-//    }
-//
-//    @AfterEach
-//    void tearDown() {
-//    }
+    @BeforeEach
+    void setUp() {
+        location = LocationFactory.createLocation("Cape Town Stadium");
+    }
 
     @Test
     public void testLocationFactoryCreate() {
-        var location = LocationFactory.createLocation("Cape Town Stadium");
         assertNotNull(location);
     }
 
     @Test
-    public void testLocationFactoryValues() {
-        var location = LocationFactory.createLocation("Cape Town Stadium");
+    public void testStadiumNameValues() {
         assertEquals("Cape Town Stadium", location.getStadiumName());
     }
 

--- a/src/test/java/za/ac/cput/factory/LocationFactoryTest.java
+++ b/src/test/java/za/ac/cput/factory/LocationFactoryTest.java
@@ -1,0 +1,55 @@
+package za.ac.cput.factory;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class LocationFactoryTest {
+
+
+//    @BeforeEach
+//    void setUp() {
+//    }
+//
+//    @AfterEach
+//    void tearDown() {
+//    }
+
+    @Test
+    public void testLocationFactoryCreate() {
+        var location = LocationFactory.createLocation("Cape Town Stadium");
+        assertNotNull(location);
+    }
+
+    @Test
+    public void testLocationFactoryValues() {
+        var location = LocationFactory.createLocation("Cape Town Stadium");
+        assertEquals("Cape Town Stadium", location.getStadiumName());
+    }
+
+    @Test
+    public void testLocationFactoryForNull() {
+        Exception exception = assertThrows(IllegalStateException.class, () -> {
+            LocationFactory.createLocation(null);
+        });
+
+        String expectedMessage = "Invalid value";
+        String actualMessage = exception.getMessage();
+
+        assertTrue(actualMessage.contains(expectedMessage));
+    }
+
+    @Test
+    public void testLocationFactoryForEmptyString() {
+        Exception exception = assertThrows(IllegalStateException.class, () -> {
+            LocationFactory.createLocation("");
+        });
+
+        String expectedMessage = "Invalid value";
+        String actualMessage = exception.getMessage();
+
+        assertTrue(actualMessage.contains(expectedMessage));
+    }
+}

--- a/src/test/java/za/ac/cput/factory/MatchFactoryTest.java
+++ b/src/test/java/za/ac/cput/factory/MatchFactoryTest.java
@@ -1,0 +1,70 @@
+package za.ac.cput.factory;
+
+/*
+ * @author Karl Haupt (220236585)
+ * MatchFactoryTest.java -> is a testing class that is used to test the MatchFactory.
+ */
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import za.ac.cput.entity.Match;
+import static org.junit.jupiter.api.Assertions.*;
+
+class MatchFactoryTest {
+    private Match match;
+
+    @BeforeEach
+    void setUp() {
+        match = MatchFactory.createMatch("Team A", "Away Kit", "12 May 2021", "14:00");
+    }
+
+    @Test
+    public void testMatchFactoryCreate() {
+        assertNotNull(match);
+    }
+
+    @Test
+    public void testMatchFactoryValueOpponent() {
+        assertEquals("Team A", match.getOpponent());
+    }
+
+    @Test
+    public void testMatchFactoryValueKitType() {
+        assertEquals("Away Kit", match.getKitType());
+    }
+
+    @Test
+    public void testMatchFactoryValueDate() {
+        assertEquals("12 May 2021", match.getDate());
+    }
+
+    @Test
+    public void testMatchFactoryValueTime() {
+        assertEquals("14:00", match.getTime());
+    }
+
+    @Test
+    public void testMatchFactoryForNull() {
+        Exception exception = assertThrows(IllegalStateException.class, () -> {
+            MatchFactory.createMatch(null, null, null, null);
+        });
+
+        String expectedMessage = "Invalid values";
+        String actualMessage = exception.getMessage();
+
+        assertTrue(actualMessage.contains(expectedMessage));
+    }
+
+    @Test
+    public void testMatchFactoryForEmptyString() {
+        Exception exception = assertThrows(IllegalStateException.class, () -> {
+            MatchFactory.createMatch("", "", "", "");
+        });
+
+        String expectedMessage = "Invalid values";
+        String actualMessage = exception.getMessage();
+
+        assertTrue(actualMessage.contains(expectedMessage));
+    }
+}

--- a/src/test/java/za/ac/cput/factory/MatchLocationFactoryTest.java
+++ b/src/test/java/za/ac/cput/factory/MatchLocationFactoryTest.java
@@ -1,0 +1,59 @@
+package za.ac.cput.factory;
+/*
+ * @author Karl Haupt (220236585)
+ * MatchLocationFactoryTest.java -> is a testing class that is used to test the MatchLocationFactory.
+ */
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import za.ac.cput.entity.MatchLocation;
+import static org.junit.jupiter.api.Assertions.*;
+
+class MatchLocationFactoryTest {
+    private MatchLocation matchLocation;
+
+    @BeforeEach
+    void setUp() {
+        matchLocation = MatchLocationFactory.createMatchLocation("12", "1");
+    }
+
+    @Test
+    public void testMatchLocationFactoryCreate() {
+        assertNotNull(matchLocation);
+    }
+
+    @Test
+    public void testMatchLocationFactoryValueLocationID() {
+        assertEquals("12", matchLocation.getLocationId());
+    }
+
+    @Test
+    public void testMatchLocationFactoryValueMatchID() {
+        assertEquals("1", matchLocation.getMatchId());
+    }
+
+    @Test
+    public void testMatchLocationFactoryForNull() {
+        Exception exception = assertThrows(IllegalStateException.class, () -> {
+            MatchLocationFactory.createMatchLocation(null, null);
+        });
+
+        String expectedMessage = "Invalid values";
+        String actualMessage = exception.getMessage();
+
+        assertTrue(actualMessage.contains(expectedMessage));
+    }
+
+    @Test
+    public void testMatchLocationFactoryForEmptyString() {
+        Exception exception = assertThrows(IllegalStateException.class, () -> {
+            MatchLocationFactory.createMatchLocation("", "");
+        });
+
+        String expectedMessage = "Invalid values";
+        String actualMessage = exception.getMessage();
+
+        assertTrue(actualMessage.contains(expectedMessage));
+    }
+
+}

--- a/src/test/java/za/ac/cput/factory/MatchScoreFactoryTest.java
+++ b/src/test/java/za/ac/cput/factory/MatchScoreFactoryTest.java
@@ -1,0 +1,64 @@
+package za.ac.cput.factory;
+
+/*
+ * @author Karl Haupt (220236585)
+ * MatchScoreFactoryTest.java -> is a testing class that is used to test the MatchScoreFactory.
+ */
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import za.ac.cput.entity.MatchScore;
+import static org.junit.jupiter.api.Assertions.*;
+
+class MatchScoreFactoryTest {
+    private MatchScore matchScore;
+
+    @BeforeEach
+    void setUp() {
+        matchScore = MatchScoreFactory.createMatchScore("1", (byte) 2, (byte) 5);
+    }
+
+    @Test
+    public void testMatchScoreFactoryCreate() {
+        assertNotNull(matchScore);
+    }
+
+    @Test
+    public void testMatchScoreFactoryValueMatchID() {
+        assertEquals("1", matchScore.getMatchID());
+    }
+
+    @Test
+    public void testMatchScoreFactoryValueOpponentScore() {
+        assertEquals(2, matchScore.getOpponentScore());
+    }
+
+    @Test
+    public void testMatchFactoryValueTeamScore() {
+        assertEquals(5, matchScore.getTeamScore());
+    }
+
+    @Test
+    public void testMatchFactoryForNull() {
+        Exception exception = assertThrows(IllegalStateException.class, () -> {
+            MatchScoreFactory.createMatchScore(null, (byte) 0, (byte) 0);
+        });
+
+        String expectedMessage = "Invalid values";
+        String actualMessage = exception.getMessage();
+
+        assertTrue(actualMessage.contains(expectedMessage));
+    }
+
+    @Test
+    public void testMatchFactoryForEmptyString() {
+        Exception exception = assertThrows(IllegalStateException.class, () -> {
+            MatchScoreFactory.createMatchScore("", (byte) 0, (byte) -1);
+        });
+
+        String expectedMessage = "Invalid values";
+        String actualMessage = exception.getMessage();
+
+        assertTrue(actualMessage.contains(expectedMessage));
+    }
+}


### PR DESCRIPTION
Implemented test suite for the these entities:

- Location
- MatchLocation
- Match
- Kit
- MatchScore

Implemented the test suite for these factories:

- LocationFactory
- MatchLocationFactory
- MatchFactory
- KitFactory
- MatchScoreFactory

This pull request also solved the meging conflict in the Helper class and adds two new methods to the helper class - isNull or IsEmpty